### PR TITLE
add: カテゴリー機能の追加 #18

### DIFF
--- a/components/CategoryList.tsx
+++ b/components/CategoryList.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Link from "next/link"
+
+const CategoryList = (props: any) => {
+  return (
+    <>
+      <div>
+        <p>下にカテゴリー名が入る。</p>
+        {/* <Link href={`/categories/${}`}></Link> */}
+        <Link href={`/categories/${props.category}`}>{props.category}</Link>
+      </div>
+    </>
+  )
+}
+
+export default CategoryList;

--- a/components/Thumb.tsx
+++ b/components/Thumb.tsx
@@ -15,8 +15,13 @@ const blogTile = {
   padding: "0",
 };
 
-const blogTitle = {
+const blogTitle: { [key: string]: string } = {
   margin: "5px 0",
+  textTransform: "none",
+};
+
+const initText: { [key: string]: string } = {
+  textTransform: "none",
 };
 
 const Thumb: React.FC<listProps> = (props) => {
@@ -31,9 +36,10 @@ const Thumb: React.FC<listProps> = (props) => {
             width={300}
           />
           <div style={blogText}>
-            <small>
+            <small style={initText}>
               <Date dateString={props.list.date} />
             </small>
+            <p style={blogTitle}>{props.list.category}</p>
             <p style={blogTitle}>{props.list.title}</p>
           </div>
         </Paper>

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,33 @@
+import { getSortedPostsData } from './posts'
+import { matterResult } from "@Modules";
+
+export function getSortedCategoryData(id: string) {
+  // fs.readFileSync(ファイルのパス、文字こーど、コールバック関数)
+
+  const allCategoryData = getSortedPostsData();
+  const categoryDataFilter = allCategoryData.filter((data) => data.category === id);
+  return JSON.parse(JSON.stringify(categoryDataFilter));
+};
+
+// カテゴリーのparams取得。
+export function getAllCategoryIds() {
+  const allCategoriesData = getSortedPostsData();
+  return allCategoriesData.map((list) => {
+    return {
+      params: {
+        category: list.category,
+      },
+    };
+  });
+};
+
+// カテゴリーページ（一覧表示：/categories）
+export async function getFilterCategoryData() {
+  const allCategoriesData = getSortedPostsData();
+  console.log(allCategoriesData.filter(data => data.category === "JavaScript"))
+  const categoryList = allCategoriesData.map(list => list.category);
+
+  const categories = [...new Set(categoryList)];
+  
+  return categories;
+};

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -39,7 +39,7 @@ export function getSortedPostsData(){
   });
 }
 
-// ブログページのマークダウン
+// ブログページのパラメータ
 export function getAllPostIds() {
   const fileNames = fs.readdirSync(articleDirectory);
   return fileNames.map((fileName) => {
@@ -51,7 +51,7 @@ export function getAllPostIds() {
   });
 }
 
-// ブログリストの参照
+// ブログの参照
 export async function getPostData(id: string) {
   const fullPath = path.join(articleDirectory, `${id}.md`);
   const fileContents = fs.readFileSync(fullPath, "utf8");

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -3,12 +3,13 @@ import path from "path";
 import matter from "gray-matter";
 import remark from "remark";
 import html from "remark-html";
+import { matterResult } from "@Modules";
 
 // postsディレクトリの読み込み
 const articleDirectory = path.join(process.cwd(), "articles");
 
 // マークダウンファイルの読み込み（TOPページ）
-export function getSortedPostsData():any{
+export function getSortedPostsData(){
   // fs.readFileSync(ファイルのパス、文字こーど、コールバック関数)
 
   const fileNames = fs.readdirSync(articleDirectory);
@@ -21,23 +22,21 @@ export function getSortedPostsData():any{
       const fileContents = fs.readFileSync(fullPath, 'utf8');
       
       // matterを使用して投稿メタデータセクションを解析します
-      const matterResult = matter(fileContents);
+      const matterResult = matter(fileContents)
       // Combine the data with the id
       return {
         paths,
-        ...(matterResult.data as { date: string; title: string; thumb: string;}),
+        ...(matterResult.data as matterResult),
       };
     });
     // 日付順にする。
-    // console.log("サーバー",allPostsData);
-    
-    return allPostsData.sort((a, b) => {
-      if (a.date < b.date) {
-        return 1;
-      } else {
-        return -1;
-      }
-    });
+  return allPostsData.sort((a, b) => {
+    if (a.date < b.date) {
+      return 1;
+    } else {
+      return -1;
+    }
+  });
 }
 
 // ブログページのマークダウン
@@ -53,7 +52,7 @@ export function getAllPostIds() {
 }
 
 // ブログリストの参照
-export async function getPostData(id:string) {
+export async function getPostData(id: string) {
   const fullPath = path.join(articleDirectory, `${id}.md`);
   const fileContents = fs.readFileSync(fullPath, "utf8");
 

--- a/modules/md.module.ts
+++ b/modules/md.module.ts
@@ -34,3 +34,10 @@ export type postData = {
   category: string,
   contentHtml: string,
 }
+
+export interface matterResult {
+  title: string;
+  thumb: string;
+  date: string;
+  category: string;
+}

--- a/pages/Blog.tsx
+++ b/pages/Blog.tsx
@@ -5,8 +5,7 @@ import { GetStaticProps } from "next";
 import Layout, { TitleText } from "@Components/Layout";
 import Article from "@Components/Article";
 
-import Thumb from "@Components/Thumb";
-import Posts from "./posts/index";
+import Posts from "@Pages/posts";
 
 import { getSortedPostsData } from "@Lib/posts";
 import { allPostsData } from "@Modules"

--- a/pages/categories/[category].tsx
+++ b/pages/categories/[category].tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Head from "next/head";
+import Layout from "@Components/Layout";
+import Thumb from "@Components/Thumb";
+
+import { getAllCategoryIds, getSortedCategoryData } from "@Lib/categories";
+
+import { GetStaticProps } from 'next';
+import { allPostsData, List } from "@Modules";
+
+// ダイナミックルータの利用時に静的なファイルとして生成するAPI。
+export const getStaticPaths = async () => {
+  const paths = getAllCategoryIds();
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps = async ({ params }:{ params: { category: string }}) => {
+  const categoryData = await getSortedCategoryData(params.category);
+  return {
+    props: {
+      categoryData,
+    },
+  };
+};
+
+const Category = ({ categoryData }: { categoryData: any }) => {
+  const data: any = categoryData;
+  console.log("カテゴリー",data);
+  return (
+    <Layout>
+      <Head>
+        <title>Kotaro Blog Category</title>
+      </Head>
+      <section>
+          <ul>
+            {data.map((list: List, id:number) => (
+              <li key={id}>
+                <Thumb list={list} />
+              </li>
+            ))}
+          </ul>
+      </section>
+    </Layout>
+  );
+};
+
+export default Category;

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import Head from "next/head";
+import { GetStaticProps } from "next";
+import Layout, { siteTitle } from "@Components/Layout";
+import CategoryList from "@Components/CategoryList";
+
+import { getFilterCategoryData } from "@Lib/categories";
+
+export const getStaticProps: GetStaticProps = async () => {
+  const categories = await getFilterCategoryData();
+  return {
+    props: {
+      categories,
+    },
+  };
+};
+
+const Categories = ({ categories }: any) => {
+  console.log(categories);
+  return (
+    <Layout>
+      <Head>
+        <title>{siteTitle}</title>
+      </Head>
+      <div>
+        <h2>カテゴリー</h2>
+        <section>
+          <ul>
+            {categories.map((category: any, id:number) => (
+              <li key={id}>
+                <CategoryList category={category} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </Layout>
+  );
+}
+
+export default Categories;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import Article from "@Components/Article";
 import { getSortedPostsData } from "@Lib/posts";
 import { allPostsData } from "@Modules"
 
-import Posts from "./posts/index";
+import Posts from "@Pages/posts";
 
 
 export const getStaticProps: GetStaticProps = async () => {

--- a/pages/posts/[post].tsx
+++ b/pages/posts/[post].tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import Layout from "@Components/Layout";
 import Date from "@Components/Time";
 import { getAllPostIds, getPostData } from "@Lib/posts";
-import { postData,params } from "@Modules";
+import { postData, params } from "@Modules";
 
 // サーバーサイドを実行しているAPI
 export const getStaticPaths = async () => {
@@ -48,7 +48,7 @@ const Post: React.FC<{postData: postData}> = ({ postData }: { postData: postData
           <Date dateString={postData.date} />
         </div>
         <div>
-          <p>{postData.category}</p>
+          <p>カテゴリー：{postData.category}</p>
         </div>
         <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
       </article>

--- a/pages/posts/[post].tsx
+++ b/pages/posts/[post].tsx
@@ -5,17 +5,17 @@ import Date from "@Components/Time";
 import { getAllPostIds, getPostData } from "@Lib/posts";
 import { postData, params } from "@Modules";
 
-// サーバーサイドを実行しているAPI
+// 事前生成するページのパス（URLのパラメータ）を返す。
 export const getStaticPaths = async () => {
   const paths = getAllPostIds();
   return {
-    paths,
+    paths, // 生成するページのパス
     fallback: false,
   };
 };
 
 // サーバーサイドを実行しているAPI
-export const getStaticProps = async ({ params }: params) => {
+export const getStaticProps = async ({ params }: any) => {
   const postData = await getPostData(params.post);
   return {
     props: {

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -26,7 +26,6 @@ const blogTitle = {
 };
 
 const list = {
-  listStyle: "none",
   display: "flex",
   cursor: "pointer",
 };
@@ -36,7 +35,7 @@ const item = {
   margin: "20px",
 };
 
-export default function Posts({ allPostsData}: {allPostsData: allPostsData}) {
+export default function Posts({ allPostsData }: { allPostsData: allPostsData }) {
   const data: any = allPostsData;
   return (
     <>

--- a/styles/global.css
+++ b/styles/global.css
@@ -21,3 +21,7 @@ img {
   max-width: 100%;
   display: block;
 }
+
+li {
+  list-style: none;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "downlevelIteration": true,
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
- /categories ページでカテゴリー一覧の表示
- /categories/[category] 該当カテゴリーのサムネ表示
- set()メソッドが古いバージョンの機能のため、`downlevelIteration`のオプションを追加